### PR TITLE
fix: support slice, array type arguments/replies

### DIFF
--- a/example/gorilla/math/client/generated_MathClient.go
+++ b/example/gorilla/math/client/generated_MathClient.go
@@ -26,3 +26,9 @@ func (c *Math) Identity(args int) (*int, error) {
 	err := c.RPC.Call("Math.Identity", args, reply)
 	return reply, err
 }
+
+func (c *Math) IdentityMany(args []int) (*[]int, error) {
+	reply := new([]int)
+	err := c.RPC.Call("Math.IdentityMany", args, reply)
+	return reply, err
+}

--- a/example/gorilla/math/service.go
+++ b/example/gorilla/math/service.go
@@ -27,3 +27,8 @@ func (s *Service) Identity(r *http.Request, arg *int, reply *int) error {
 	*reply = *arg
 	return nil
 }
+
+func (s *Service) IdentityMany(r *http.Request, arg *[]int, reply *[]int) error {
+	reply = arg
+	return nil
+}


### PR DESCRIPTION
When checking whether a type was exported or a primitive, we did
not previously consider complex types, like slices or arrays.
Now, Unpack() recursively inspects those.