### PR TITLE
refactor to properly support complex types

### DIFF
--- a/bindata.go
+++ b/bindata.go
@@ -83,7 +83,7 @@ func templatesClientGohtml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/client.gohtml", size: 560, mode: os.FileMode(420), modTime: time.Unix(1494292301, 0)}
+	info := bindataFileInfo{name: "templates/client.gohtml", size: 560, mode: os.FileMode(420), modTime: time.Unix(1494295523, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/example/gorilla/math/client/generated_MathClient.go
+++ b/example/gorilla/math/client/generated_MathClient.go
@@ -32,3 +32,9 @@ func (c *Math) IdentityMany(args []int) (*[]int, error) {
 	err := c.RPC.Call("Math.IdentityMany", args, reply)
 	return reply, err
 }
+
+func (c *Math) IdentityManyStruct(args []math.IdentityStruct) (*[]math.IdentityStruct, error) {
+	reply := new([]math.IdentityStruct)
+	err := c.RPC.Call("Math.IdentityManyStruct", args, reply)
+	return reply, err
+}

--- a/example/gorilla/math/service.go
+++ b/example/gorilla/math/service.go
@@ -32,3 +32,15 @@ func (s *Service) IdentityMany(r *http.Request, arg *[]int, reply *[]int) error 
 	reply = arg
 	return nil
 }
+
+type IdentityStruct struct {
+	Val int
+}
+
+func (s *Service) IdentityManyStruct(r *http.Request, arg *[]*IdentityStruct, reply *[]IdentityStruct) error {
+	*reply = []IdentityStruct{}
+	for _, a := range *arg {
+		*reply = append(*reply, IdentityStruct{a.Val})
+	}
+	return nil
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -1,7 +1,6 @@
 package provider
 
 import (
-	"fmt"
 	"go/types"
 )
 
@@ -14,15 +13,6 @@ type Provider interface {
 
 // TypeInfo contains metadata about input/output types.
 type TypeInfo struct {
-	Name    string
-	Package *types.Package
-}
-
-// Identifier returns the identifier path for a type (e.g. pkg.SomeStruct, int64).
-func (t TypeInfo) Identifier() string {
-	if t.Package == nil {
-		return t.Name
-	}
-
-	return fmt.Sprintf("%s.%s", t.Package.Name(), t.Name)
+	Identifier string
+	Imports    []string
 }

--- a/walker.go
+++ b/walker.go
@@ -1,6 +1,7 @@
 package glue
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 
@@ -59,6 +60,11 @@ func (w *Walker) walkPackage(pkg *loader.PackageInfo, decl, service string) erro
 		Declaration: decl,
 	})
 	funcsByRecv := visitor.Go()
+
+	if len(funcsByRecv) == 0 {
+		log.Error("could not find any RPC services")
+		return errors.New("not found")
+	}
 
 	for _, funcs := range funcsByRecv {
 		generator := Generator{


### PR DESCRIPTION
This refactors the provider/ model to properly support complex types.
Previously, our unpacking relied on String() methods, which were not
right when dealing with non-basic types. The examples/ now test both
arrays of structs and primitives. Maps, slices, and all combinations
of complex types (e.g. []map[k]v) should be supported.

In addition, I've deleted some dead code and removed repeated work
when deriving function's req/res imports. I'll try to separate this
next time.